### PR TITLE
add python-pymysql as prerequisite (only need on the master of the ga…

### DIFF
--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -6,6 +6,7 @@ mariadb_pre_req_packages:
   - "python3-pymysql"
   - "rsync"
   - "gnupg"
+  - "python-pymysql"
 mariadb_debian_repo_key: "0xF1656F24C74CD1D8"
 mariadb_packages:
   - "mariadb-server"


### PR DESCRIPTION
…lera custer)

Otherwise will get a error on the tasks ansible-mariadb-galera-cluster : configure_root_access | updating root passwords:
```
TASK [ansible-mariadb-galera-cluster : configure_root_access | updating root passwords] ********************************************************
failed: [sql3] (item=sql3) => {"ansible_loop_var": "item", "changed": false, "item": "sql3", "msg": "The PyMySQL (Python 2.7 and Python 3.X) or MySQL-python (Python 2.X) module is required."}
```