### PR TITLE
bump ansible min version to 2.10

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
 
   license: MIT
 
-  min_ansible_version: 2.9
+  min_ansible_version: 2.10
   platforms:
     - name: EL
       versions:


### PR DESCRIPTION
As on the file tasks/mysql_users.yml (tasks `mysql_users | create MySQL users`)
it's use the plugin attribut (added in 2.10 , 0.1.0 of community.mysql)